### PR TITLE
Truncate long lines via Lip Gloss's MaxWidth

### DIFF
--- a/branch.go
+++ b/branch.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
-	"github.com/muesli/reflow/truncate"
 	"github.com/shurcooL/githubv4"
 )
 
@@ -64,7 +63,7 @@ func printBranch(branch Branch, maxWidth int) {
 	var s string
 	s += numberStyle.Render(branch.Name)
 	s += genericStyle.Render(" ")
-	s += titleStyle.Render(truncate.String(branch.LastCommit.MessageHeadline, uint(80-maxWidth)))
+	s += titleStyle.MaxWidth(80 - maxWidth).Render(branch.LastCommit.MessageHeadline)
 	s += genericStyle.Render(" ")
 	s += timeStyle.Render(ago(branch.LastCommit.CommittedAt))
 	s += genericStyle.Render(" ")

--- a/commit.go
+++ b/commit.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
-	"github.com/muesli/reflow/truncate"
 	"github.com/shurcooL/githubv4"
 )
 
@@ -94,7 +93,7 @@ func printCommit(commit Commit) {
 	var s string
 	s += numberStyle.Render(commit.ID[:7])
 	s += genericStyle.Render(" ")
-	s += titleStyle.Render(truncate.String(commit.MessageHeadline, 80-7))
+	s += titleStyle.MaxWidth(80 - 7).Render(commit.MessageHeadline)
 	s += genericStyle.Render(" ")
 	s += timeStyle.Render(ago(commit.CommittedAt))
 	s += genericStyle.Render(" ")

--- a/issue.go
+++ b/issue.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
-	"github.com/muesli/reflow/truncate"
 	"github.com/shurcooL/githubv4"
 )
 
@@ -105,7 +104,7 @@ func printIssue(issue Issue, maxWidth int) {
 	var s string
 	s += numberStyle.Render(strconv.Itoa(issue.ID))
 	s += genericStyle.Render(" ")
-	s += titleStyle.Render(truncate.String(issue.Title, uint(80-maxWidth)))
+	s += titleStyle.MaxWidth(80 - maxWidth).Render(issue.Title)
 	s += genericStyle.Render(" ")
 	s += timeStyle.Render(ago(issue.CreatedAt))
 	s += genericStyle.Render(" ")

--- a/pr.go
+++ b/pr.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
-	"github.com/muesli/reflow/truncate"
 	"github.com/shurcooL/githubv4"
 )
 
@@ -106,7 +105,7 @@ func printPullRequest(pr PullRequest, maxWidth int) {
 	var s string
 	s += numberStyle.Render(strconv.Itoa(pr.ID))
 	s += genericStyle.Render(" ")
-	s += titleStyle.Render(truncate.String(pr.Title, uint(80-maxWidth)))
+	s += titleStyle.MaxWidth(80 - maxWidth).Render(pr.Title)
 	s += genericStyle.Render(" ")
 	s += timeStyle.Render(ago(pr.CreatedAt))
 	s += genericStyle.Render(" ")


### PR DESCRIPTION
This tiny PR simplifies truncation with Lip Gloss's [`MaxWidth()`](https://pkg.go.dev/github.com/charmbracelet/lipgloss@v0.4.0#Style.MaxWidth) method. `reflow` is still doing the actual truncation under the hood, of course.

Essentially code like this:
```go
style.Render(truncate.String(str, uint(80-maxWidth)))
```
Becomes this:
```go
style.MaxWidth(80 - maxWidth).Render(str)
```

Functionally speaking, there are no changes in this PR — it's merely a code style option.