### PR TITLE
Pluralize headers according to number of available entries

### DIFF
--- a/branch.go
+++ b/branch.go
@@ -101,7 +101,7 @@ func printBranches(branches []Branch) {
 		// trimmed = true
 	}
 
-	fmt.Println(headerStyle.Render(fmt.Sprintf("🌳 %d active branches", len(branches))))
+	fmt.Println(headerStyle.Render(fmt.Sprintf("%s %s", "🌳", pluralize(len(branches), "active branch", "active branches"))))
 
 	// detect max width of branch name
 	var maxWidth int

--- a/commit.go
+++ b/commit.go
@@ -114,11 +114,8 @@ func printCommits(repo Repo) {
 	if sinceTag == "" {
 		sinceTag = "creation"
 	}
-	if len(commits) == 0 {
-		fmt.Println(headerStyle.Render(fmt.Sprintf("🔥 No new commits since %s", sinceTag)))
-		return
-	}
-	fmt.Println(headerStyle.Render(fmt.Sprintf("🔥 %d commits since %s", len(commits), sinceTag)))
+
+	fmt.Println(headerStyle.Render(fmt.Sprintf("%s %s %s", "🔥", pluralize(len(commits), "commit since", "commits since"), sinceTag)))
 
 	// trimmed := false
 	if *maxCommits > 0 && len(commits) > *maxCommits {

--- a/issue.go
+++ b/issue.go
@@ -127,7 +127,7 @@ func printIssues(issues []Issue) {
 		PaddingTop(1).
 		Foreground(lipgloss.Color(theme.colorMagenta))
 
-	fmt.Println(headerStyle.Render(fmt.Sprintf("🐛 %d open issues", len(issues))))
+	fmt.Println(headerStyle.Render(fmt.Sprintf("%s %s", "🐛", pluralize(len(issues), "open issue", "open issues"))))
 
 	// trimmed := false
 	if *maxIssues > 0 && len(issues) > *maxIssues {

--- a/main.go
+++ b/main.go
@@ -239,3 +239,13 @@ func ago(t time.Time) string {
 
 	return s
 }
+
+func pluralize(count int, singular string, plural string) string {
+	if count == 0 {
+		return fmt.Sprintf("No %s", plural)
+	} else if count == 1 {
+		return fmt.Sprintf("1 %s", singular)
+	} else {
+		return fmt.Sprintf("%d %s", count, plural)
+	}
+}

--- a/pr.go
+++ b/pr.go
@@ -128,7 +128,7 @@ func printPullRequests(prs []PullRequest) {
 		PaddingTop(1).
 		Foreground(lipgloss.Color(theme.colorMagenta))
 
-	fmt.Println(headerStyle.Render(fmt.Sprintf("📌 %d open pull requests", len(prs))))
+	fmt.Println(headerStyle.Render(fmt.Sprintf("%s %s", "📌", pluralize(len(prs), "open pull request", "open pull requests"))))
 
 	// trimmed := false
 	if *maxPullRequests > 0 && len(prs) > *maxPullRequests {


### PR DESCRIPTION
Makes it easier to read the repository 'report'.

Edit:
Just thought about to add the date of the last tag / creation of the repo.

I think it would add some valuable information but introduces the problem of date formatting, what do you think?