### PR TITLE
Truncate strings with an ellipsis

### DIFF
--- a/branch.go
+++ b/branch.go
@@ -66,7 +66,7 @@ func printBranch(branch Branch, maxWidth int) {
 	var s string
 	s += numberStyle.Render(branch.Name)
 	s += genericStyle.Render(" ")
-	s += titleStyle.Render(truncate.String(branch.LastCommit.MessageHeadline, uint(80-maxWidth)))
+	s += titleStyle.Render(truncate.StringWithTail(branch.LastCommit.MessageHeadline, uint(80-maxWidth), "…"))
 	s += genericStyle.Render(" ")
 	s += timeStyle.Render(ago(branch.LastCommit.CommittedAt))
 	s += genericStyle.Render(" ")

--- a/commit.go
+++ b/commit.go
@@ -94,7 +94,7 @@ func printCommit(commit Commit) {
 	var s string
 	s += numberStyle.Render(commit.ID[:7])
 	s += genericStyle.Render(" ")
-	s += titleStyle.Render(truncate.String(commit.MessageHeadline, 80-7))
+	s += titleStyle.Render(truncate.StringWithTail(commit.MessageHeadline, 80-7, "…"))
 	s += genericStyle.Render(" ")
 	s += timeStyle.Render(ago(commit.CommittedAt))
 	s += genericStyle.Render(" ")

--- a/issue.go
+++ b/issue.go
@@ -105,7 +105,7 @@ func printIssue(issue Issue, maxWidth int) {
 	var s string
 	s += numberStyle.Render(strconv.Itoa(issue.ID))
 	s += genericStyle.Render(" ")
-	s += titleStyle.Render(truncate.String(issue.Title, uint(80-maxWidth)))
+	s += titleStyle.Render(truncate.StringWithTail(issue.Title, uint(80-maxWidth), "…"))
 	s += genericStyle.Render(" ")
 	s += timeStyle.Render(ago(issue.CreatedAt))
 	s += genericStyle.Render(" ")

--- a/pr.go
+++ b/pr.go
@@ -106,7 +106,7 @@ func printPullRequest(pr PullRequest, maxWidth int) {
 	var s string
 	s += numberStyle.Render(strconv.Itoa(pr.ID))
 	s += genericStyle.Render(" ")
-	s += titleStyle.Render(truncate.String(pr.Title, uint(80-maxWidth)))
+	s += titleStyle.Render(truncate.StringWithTail(pr.Title, uint(80-maxWidth), "…"))
 	s += genericStyle.Render(" ")
 	s += timeStyle.Render(ago(pr.CreatedAt))
 	s += genericStyle.Render(" ")


### PR DESCRIPTION
Uses `truncate.StringWithTail` instead of a hard cut.