### PR TITLE
Prefill new token description and scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,7 @@ Compiling gitty is easy, simply run:
 
 Note: In order to access GitHub's API, `gitty` requires you to provide a valid
 GitHub token in an environment variable called either `GITHUB_TOKEN` or
-`GITTY_TOKEN`. You can create a new token in your
-[profile settings](https://github.com/settings/tokens):
+`GITTY_TOKEN`. You can [create a new token](https://github.com/settings/tokens/new?scopes=repo:status,public_repo,read:user,read:org&description=gitty) in your profile settings:
 
 `Developer settings` > `Personal access tokens` > `Generate new token`
 


### PR DESCRIPTION
As per issue #12 this change pre-fills the minimum required scopes for the personal access token.
I've also included a default description of 'gitty' for the 'note' field.
Since the link now points directly to the 'new token' form, I've also changed the clickable part of the sentence from 'profile settings' to 'create a new token' to better reflect the action of the link.