### PR TITLE
Avoid accessing loop value's reference

### DIFF
--- a/vcs/github/issue.go
+++ b/vcs/github/issue.go
@@ -38,16 +38,15 @@ type QLIssue struct {
 }
 
 func (c *Client) Issues(owner string, name string) ([]vcs.Issue, error) {
-	var after *githubv4.String
 	var issues []vcs.Issue
 
-	for {
-		variables := map[string]interface{}{
-			"owner": githubv4.String(owner),
-			"name":  githubv4.String(name),
-			"after": after,
-		}
+	variables := map[string]interface{}{
+		"owner": githubv4.String(owner),
+		"name":  githubv4.String(name),
+		"after": (*githubv4.String)(nil),
+	}
 
+	for {
 		if err := c.queryWithRetry(context.Background(), &issuesQuery, variables); err != nil {
 			return issues, err
 		}
@@ -58,7 +57,7 @@ func (c *Client) Issues(owner string, name string) ([]vcs.Issue, error) {
 		for _, v := range issuesQuery.Repository.Issues.Edges {
 			issues = append(issues, IssueFromQL(v.Node.QLIssue))
 
-			after = &v.Cursor
+			variables["after"] = githubv4.NewString(v.Cursor)
 		}
 	}
 

--- a/vcs/github/pr.go
+++ b/vcs/github/pr.go
@@ -38,16 +38,15 @@ type QLPullRequest struct {
 }
 
 func (c *Client) PullRequests(owner string, name string) ([]vcs.PullRequest, error) {
-	var after *githubv4.String
 	var pullRequests []vcs.PullRequest
 
-	for {
-		variables := map[string]interface{}{
-			"owner": githubv4.String(owner),
-			"name":  githubv4.String(name),
-			"after": after,
-		}
+	variables := map[string]interface{}{
+		"owner": githubv4.String(owner),
+		"name":  githubv4.String(name),
+		"after": (*githubv4.String)(nil),
+	}
 
+	for {
 		if err := c.queryWithRetry(context.Background(), &pullRequestQuery, variables); err != nil {
 			return pullRequests, err
 		}
@@ -58,7 +57,7 @@ func (c *Client) PullRequests(owner string, name string) ([]vcs.PullRequest, err
 		for _, v := range pullRequestQuery.Repository.PullRequests.Edges {
 			pullRequests = append(pullRequests, PullRequestFromQL(v.Node.QLPullRequest))
 
-			after = &v.Cursor
+			variables["after"] = githubv4.NewString(v.Cursor)
 		}
 	}
 

--- a/vcs/github/repos.go
+++ b/vcs/github/repos.go
@@ -72,15 +72,14 @@ func (c *Client) Repository(owner string, name string) (vcs.Repo, error) {
 }
 
 func (c *Client) Repositories(owner string) ([]vcs.Repo, error) {
-	var after *githubv4.String
 	var repos []vcs.Repo
 
-	for {
-		variables := map[string]interface{}{
-			"username": githubv4.String(owner),
-			"after":    after,
-		}
+	variables := map[string]interface{}{
+		"username": githubv4.String(owner),
+		"after":    (*githubv4.String)(nil),
+	}
 
+	for {
 		if err := c.queryWithRetry(context.Background(), &reposQuery, variables); err != nil {
 			return nil, err
 		}
@@ -96,7 +95,7 @@ func (c *Client) Repositories(owner string) ([]vcs.Repo, error) {
 
 			repos = append(repos, repo)
 
-			after = &v.Cursor
+			variables["after"] = githubv4.NewString(v.Cursor)
 		}
 	}
 


### PR DESCRIPTION
As we only ever access the last iteration's reference this hasn't been a real problem before, but this feels a lot cleaner.