### PR TITLE
Show branch track stats for active branches

### DIFF
--- a/branch.go
+++ b/branch.go
@@ -42,24 +42,6 @@ func printBranches(branches []vcs.Branch, stats map[string]*trackStat) {
 		PaddingTop(1).
 		Foreground(lipgloss.Color(theme.colorMagenta))
 
-	sort.Slice(branches, func(i, j int) bool {
-		if branches[i].LastCommit.CommittedAt.Equal(branches[j].LastCommit.CommittedAt) {
-			return strings.Compare(branches[i].Name, branches[j].Name) < 0
-		}
-		return branches[i].LastCommit.CommittedAt.After(branches[j].LastCommit.CommittedAt)
-	})
-
-	// filter list
-	var b []vcs.Branch //nolint
-	for _, v := range branches {
-		if *maxBranchAge > 0 &&
-			v.LastCommit.CommittedAt.Before(time.Now().Add(-24*time.Duration(*maxBranchAge)*time.Hour)) {
-			continue
-		}
-		b = append(b, v)
-	}
-	branches = b
-
 	// trimmed := false
 	if *maxBranches > 0 && len(branches) > *maxBranches {
 		branches = branches[:*maxBranches]
@@ -86,4 +68,25 @@ func printBranches(branches []vcs.Branch, stats map[string]*trackStat) {
 	// if trimmed {
 	// 	fmt.Println("...")
 	// }
+}
+
+func filterBranches(branches []vcs.Branch) []vcs.Branch {
+	sort.Slice(branches, func(i, j int) bool {
+		if branches[i].LastCommit.CommittedAt.Equal(branches[j].LastCommit.CommittedAt) {
+			return strings.Compare(branches[i].Name, branches[j].Name) < 0
+		}
+		return branches[i].LastCommit.CommittedAt.After(branches[j].LastCommit.CommittedAt)
+	})
+
+	// filter list
+	var b []vcs.Branch //nolint
+	for _, v := range branches {
+		if *maxBranchAge > 0 &&
+			v.LastCommit.CommittedAt.Before(time.Now().Add(-24*time.Duration(*maxBranchAge)*time.Hour)) {
+			continue
+		}
+		b = append(b, v)
+	}
+	branches = b
+	return branches
 }

--- a/branch.go
+++ b/branch.go
@@ -21,14 +21,14 @@ func printBranch(branch vcs.Branch, stat *trackStat, maxWidth int) {
 	timeStyle := lipgloss.NewStyle().
 		Foreground(lipgloss.Color(theme.colorGreen)).Width(8).Align(lipgloss.Right)
 	titleStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color(theme.colorDarkGray)).Width(71 - maxWidth)
+		Foreground(lipgloss.Color(theme.colorDarkGray)).Width(70 - maxWidth)
 
 	var s string
 	s += numberStyle.Render(branch.Name)
 	s += genericStyle.Render(" ")
 	s += stat.Render()
 	s += genericStyle.Render(" ")
-	s += titleStyle.Render(truncate.StringWithTail(branch.LastCommit.MessageHeadline, uint(71-maxWidth), "…"))
+	s += titleStyle.Render(truncate.StringWithTail(branch.LastCommit.MessageHeadline, uint(70-maxWidth), "…"))
 	s += genericStyle.Render(" ")
 	s += timeStyle.Render(ago(branch.LastCommit.CommittedAt))
 	s += genericStyle.Render(" ")

--- a/branch.go
+++ b/branch.go
@@ -11,22 +11,32 @@ import (
 	"github.com/muesli/reflow/truncate"
 )
 
-func printBranch(branch vcs.Branch, maxWidth int) {
+func printBranch(branch vcs.Branch, stat *trackStat, maxWidth int) {
 	genericStyle := lipgloss.NewStyle().
 		Foreground(lipgloss.Color(theme.colorGray))
 	numberStyle := lipgloss.NewStyle().
 		Foreground(lipgloss.Color(theme.colorBlue)).Width(maxWidth)
+	statStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color(theme.colorGreen)).Width(4).Align(lipgloss.Right)
 	authorStyle := lipgloss.NewStyle().
 		Foreground(lipgloss.Color(theme.colorBlue))
 	timeStyle := lipgloss.NewStyle().
 		Foreground(lipgloss.Color(theme.colorGreen)).Width(8).Align(lipgloss.Right)
 	titleStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color(theme.colorDarkGray)).Width(80 - maxWidth)
+		Foreground(lipgloss.Color(theme.colorDarkGray)).Width(71 - maxWidth)
 
 	var s string
 	s += numberStyle.Render(branch.Name)
 	s += genericStyle.Render(" ")
-	s += titleStyle.Render(truncate.StringWithTail(branch.LastCommit.MessageHeadline, uint(80-maxWidth), "…"))
+	if stat != nil {
+		s += statStyle.Render(stat.AheadString())
+		s += statStyle.Render(stat.BehindString())
+	} else {
+		s += statStyle.Render(" ")
+		s += statStyle.Render(" ")
+	}
+	s += genericStyle.Render(" ")
+	s += titleStyle.Render(truncate.StringWithTail(branch.LastCommit.MessageHeadline, uint(71-maxWidth), "…"))
 	s += genericStyle.Render(" ")
 	s += timeStyle.Render(ago(branch.LastCommit.CommittedAt))
 	s += genericStyle.Render(" ")
@@ -35,7 +45,7 @@ func printBranch(branch vcs.Branch, maxWidth int) {
 	fmt.Println(s)
 }
 
-func printBranches(branches []vcs.Branch) {
+func printBranches(branches []vcs.Branch, stats map[string]*trackStat) {
 	headerStyle := lipgloss.NewStyle().
 		PaddingTop(1).
 		Foreground(lipgloss.Color(theme.colorMagenta))
@@ -75,7 +85,11 @@ func printBranches(branches []vcs.Branch) {
 	}
 
 	for _, v := range branches {
-		printBranch(v, maxWidth)
+		stat, ok := stats[v.Name]
+		if !ok {
+			stat = nil
+		}
+		printBranch(v, stat, maxWidth)
 	}
 	// if trimmed {
 	// 	fmt.Println("...")

--- a/branch.go
+++ b/branch.go
@@ -16,8 +16,6 @@ func printBranch(branch vcs.Branch, stat *trackStat, maxWidth int) {
 		Foreground(lipgloss.Color(theme.colorGray))
 	numberStyle := lipgloss.NewStyle().
 		Foreground(lipgloss.Color(theme.colorBlue)).Width(maxWidth)
-	statStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color(theme.colorGreen)).Width(4).Align(lipgloss.Right)
 	authorStyle := lipgloss.NewStyle().
 		Foreground(lipgloss.Color(theme.colorBlue))
 	timeStyle := lipgloss.NewStyle().
@@ -28,13 +26,7 @@ func printBranch(branch vcs.Branch, stat *trackStat, maxWidth int) {
 	var s string
 	s += numberStyle.Render(branch.Name)
 	s += genericStyle.Render(" ")
-	if stat != nil {
-		s += statStyle.Render(stat.AheadString())
-		s += statStyle.Render(stat.BehindString())
-	} else {
-		s += statStyle.Render(" ")
-		s += statStyle.Render(" ")
-	}
+	s += stat.Render()
 	s += genericStyle.Render(" ")
 	s += titleStyle.Render(truncate.StringWithTail(branch.LastCommit.MessageHeadline, uint(71-maxWidth), "…"))
 	s += genericStyle.Render(" ")

--- a/main.go
+++ b/main.go
@@ -138,10 +138,11 @@ func parseRepository() {
 	stbrs := make(chan []vcs.Branch)
 	go func() {
 		b := <-brs
-		go func() { stbrs <- b }()
 		if s, err := getBranchTrackStats(arg, rn, b); err != nil {
+			stbrs <- b
 			sts <- map[string]*trackStat{}
 		} else {
+			stbrs <- b
 			sts <- s
 		}
 	}()

--- a/main.go
+++ b/main.go
@@ -130,14 +130,15 @@ func parseRepository() {
 			fmt.Println(err)
 			os.Exit(1)
 		}
-		brs <- b
+		brs <- filterBranches(b)
 	}()
 
 	// get branch stats
 	sts := make(chan map[string]*trackStat)
+	stbrs := make(chan []vcs.Branch)
 	go func() {
 		b := <-brs
-		go func() { brs <- b }()
+		go func() { stbrs <- b }()
 		if s, err := getBranchTrackStats(arg, rn, b); err != nil {
 			sts <- map[string]*trackStat{}
 		} else {
@@ -164,7 +165,7 @@ func parseRepository() {
 
 	printIssues(<-is)
 	printPullRequests(<-prs)
-	printBranches(<-brs, <-sts)
+	printBranches(<-stbrs, <-sts)
 	printCommits(<-repo)
 }
 

--- a/track.go
+++ b/track.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 
+	"github.com/charmbracelet/lipgloss"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
@@ -13,8 +14,31 @@ import (
 const maxTrackStatCount = 99
 
 type trackStat struct {
-	Ahead  int
-	Behind int
+	Outdated bool
+	Ahead    int
+	Behind   int
+}
+
+func (s *trackStat) Render() string {
+	genericStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color(theme.colorGray))
+	outdatedStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color(theme.colorRed))
+	statCountStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color(theme.colorGreen)).Width(4).Align(lipgloss.Right)
+	if s == nil {
+		return genericStyle.Render(" ") + statCountStyle.Render(" ") + statCountStyle.Render(" ")
+	} else {
+		str := ""
+		if s.Outdated {
+			str += outdatedStyle.Render("↻")
+		} else {
+			str += genericStyle.Render(" ")
+		}
+		str += statCountStyle.Render(s.AheadString())
+		str += statCountStyle.Render(s.BehindString())
+		return str
+	}
 }
 
 func (s trackStat) AheadString() string {
@@ -61,13 +85,10 @@ func getBranchTrackStats(path string, remote string, trackedRemoteBranches []vcs
 	for _, remoteBranch := range trackedRemoteBranches {
 		var result *trackStat = nil
 		if b, ok := trackedBranchMap[remoteBranch.Name]; !ok {
-		} else if localBranch, err := repo.Branch(b.Name); err != nil {
-		} else if localRef, err := repo.Reference(plumbing.NewBranchReferenceName(localBranch.Name), true); err != nil {
-		} else if remoteRef, err := repo.Reference(plumbing.NewRemoteReferenceName(remote, remoteBranch.Name), true); err != nil {
-		} else if remoteRef.Hash().String() != remoteBranch.LastCommit.ID {
-			// TODO: mark out of sync
 		} else {
-			result = getTrackStat(repo, [2]plumbing.Hash{remoteRef.Hash(), localRef.Hash()})
+			if result, err = getTrackStat(repo, b, &remoteBranch); err != nil {
+				result = nil
+			}
 		}
 		results[remoteBranch.Name] = result
 	}
@@ -91,15 +112,42 @@ func getAhead(repo *git.Repository, ref plumbing.Hash, base plumbing.Hash) (int,
 	return counter, nil
 }
 
-func getTrackStat(repo *git.Repository, hashes [2]plumbing.Hash) *trackStat {
-	if ahead, err := getAhead(repo, hashes[0], hashes[1]); err != nil {
-		return nil
-	} else if behind, err := getAhead(repo, hashes[1], hashes[0]); err != nil {
-		return nil
+func getTrackStat(repo *git.Repository, rawLocalBranch *config.Branch, remoteBranch *vcs.Branch) (*trackStat, error) {
+	if localBranch, err := repo.Branch(rawLocalBranch.Name); err != nil {
+		return nil, err
+	} else if localRef, err := repo.Reference(
+		plumbing.NewBranchReferenceName(localBranch.Name), true,
+	); err != nil {
+		return nil, err
+	} else if remoteRef, err := repo.Reference(
+		plumbing.NewRemoteReferenceName(localBranch.Remote, remoteBranch.Name), true,
+	); err != nil {
+		return nil, err
 	} else {
-		return &trackStat{
-			Ahead:  ahead,
-			Behind: behind,
+		stat := &trackStat{
+			Outdated: false,
+			Ahead:    0,
+			Behind:   0,
 		}
+
+		if stat.Ahead, stat.Behind, err = calculateTrackCount(
+			repo, [2]plumbing.Hash{remoteRef.Hash(), localRef.Hash()},
+		); err != nil {
+			return nil, err
+		}
+
+		if remoteRef.Hash().String() != remoteBranch.LastCommit.ID {
+			// mark outdated, need `git fetch`
+			stat.Outdated = true
+		}
+		return stat, nil
 	}
+}
+
+func calculateTrackCount(repo *git.Repository, hashes [2]plumbing.Hash) (ahead, behind int, err error) {
+	if ahead, err = getAhead(repo, hashes[0], hashes[1]); err != nil {
+		return
+	}
+	behind, err = getAhead(repo, hashes[1], hashes[0])
+	return
 }

--- a/track.go
+++ b/track.go
@@ -126,7 +126,7 @@ func getTrackStat(repo *git.Repository, rawLocalBranch *config.Branch, remoteBra
 		}
 
 		if stat.Ahead, stat.Behind, err = calculateTrackCount(
-			repo, remoteRef.Hash(), localRef.Hash(),
+			repo, localRef.Hash(), remoteRef.Hash(),
 		); err != nil {
 			return nil, err
 		}

--- a/track.go
+++ b/track.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/revlist"
+	"github.com/muesli/gitty/vcs"
+)
+
+const maxTrackStatCount = 99
+
+type trackStat struct {
+	Ahead  int
+	Behind int
+}
+
+func (s trackStat) AheadString() string {
+	if s.Ahead > maxTrackStatCount {
+		return fmt.Sprintf("%d+↑", maxTrackStatCount)
+	} else {
+		return fmt.Sprintf("%d↑", s.Ahead)
+	}
+}
+
+func (s trackStat) BehindString() string {
+	if s.Behind > maxTrackStatCount {
+		return fmt.Sprintf("%d+↓", maxTrackStatCount)
+	} else {
+		return fmt.Sprintf("%d↓", s.Behind)
+	}
+}
+
+func getBranchTrackStats(path string, remote string, trackedRemoteBranches []vcs.Branch) (map[string]*trackStat, error) {
+	repo, err := git.PlainOpen(path)
+	if err != nil {
+		return nil, err
+	}
+
+	iter, err := repo.Branches()
+	if err != nil {
+		return nil, err
+	}
+
+	trackedBranchMap := make(map[string]*config.Branch)
+
+	if err := iter.ForEach(func(branchRef *plumbing.Reference) error {
+		if b, err := repo.Branch(branchRef.Name().Short()); err == nil {
+			if b.Remote == remote {
+				trackedBranchMap[b.Merge.Short()] = b
+			}
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	results := make(map[string]*trackStat, len(trackedRemoteBranches))
+	for _, remoteBranch := range trackedRemoteBranches {
+		var result *trackStat = nil
+		if b, ok := trackedBranchMap[remoteBranch.Name]; !ok {
+		} else if localBranch, err := repo.Branch(b.Name); err != nil {
+		} else if localRef, err := repo.Reference(plumbing.NewBranchReferenceName(localBranch.Name), true); err != nil {
+		} else if remoteRef, err := repo.Reference(plumbing.NewRemoteReferenceName(remote, remoteBranch.Name), true); err != nil {
+		} else if remoteRef.Hash().String() != remoteBranch.LastCommit.ID {
+			// TODO: mark out of sync
+		} else {
+			result = getTrackStat(repo, [2]plumbing.Hash{remoteRef.Hash(), localRef.Hash()})
+		}
+		results[remoteBranch.Name] = result
+	}
+	return results, nil
+}
+
+func getAhead(repo *git.Repository, ref plumbing.Hash, base plumbing.Hash) (int, error) {
+	hashes, err := revlist.Objects(repo.Storer,
+		[]plumbing.Hash{ref},
+		[]plumbing.Hash{base},
+	)
+	if err != nil {
+		return 0, err
+	}
+	counter := 0
+	for _, hash := range hashes {
+		if c, err := repo.CommitObject(hash); err == nil && c != nil {
+			counter++
+		}
+	}
+	return counter, nil
+}
+
+func getTrackStat(repo *git.Repository, hashes [2]plumbing.Hash) *trackStat {
+	if ahead, err := getAhead(repo, hashes[0], hashes[1]); err != nil {
+		return nil
+	} else if behind, err := getAhead(repo, hashes[1], hashes[0]); err != nil {
+		return nil
+	} else {
+		return &trackStat{
+			Ahead:  ahead,
+			Behind: behind,
+		}
+	}
+}

--- a/track.go
+++ b/track.go
@@ -26,6 +26,8 @@ func (s *trackStat) Render() string {
 		Foreground(lipgloss.Color(theme.colorRed))
 	statCountStyle := lipgloss.NewStyle().
 		Foreground(lipgloss.Color(theme.colorGreen)).Width(4).Align(lipgloss.Right)
+	statCountWarnStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color(theme.colorYellow)).Width(4).Align(lipgloss.Right)
 	if s == nil {
 		return genericStyle.Render(" ") + statCountStyle.Render(" ") + statCountStyle.Render(" ")
 	} else {
@@ -35,14 +37,21 @@ func (s *trackStat) Render() string {
 		} else {
 			str += genericStyle.Render(" ")
 		}
-		str += statCountStyle.Render(s.AheadString())
-		str += statCountStyle.Render(s.BehindString())
+		if s.Ahead > 0 || s.Behind > 0 {
+			str += statCountWarnStyle.Render(s.AheadString())
+			str += statCountWarnStyle.Render(s.BehindString())
+		} else {
+			str += statCountStyle.Render(s.AheadString())
+			str += statCountStyle.Render(s.BehindString())
+		}
 		return str
 	}
 }
 
 func (s trackStat) AheadString() string {
-	if s.Ahead > maxTrackStatCount {
+	if s.Ahead == 0 {
+		return "↑"
+	} else if s.Ahead > maxTrackStatCount {
 		return fmt.Sprintf("%d+↑", maxTrackStatCount)
 	} else {
 		return fmt.Sprintf("%d↑", s.Ahead)
@@ -50,7 +59,9 @@ func (s trackStat) AheadString() string {
 }
 
 func (s trackStat) BehindString() string {
-	if s.Behind > maxTrackStatCount {
+	if s.Behind == 0 {
+		return "↓"
+	} else if s.Behind > maxTrackStatCount {
 		return fmt.Sprintf("%d+↓", maxTrackStatCount)
 	} else {
 		return fmt.Sprintf("%d↓", s.Behind)

--- a/track.go
+++ b/track.go
@@ -24,12 +24,14 @@ func (s *trackStat) Render() string {
 		Foreground(lipgloss.Color(theme.colorGray))
 	outdatedStyle := lipgloss.NewStyle().
 		Foreground(lipgloss.Color(theme.colorRed))
+	remoteStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color(theme.colorCyan))
 	statCountStyle := lipgloss.NewStyle().
 		Foreground(lipgloss.Color(theme.colorGreen)).Width(4).Align(lipgloss.Right)
 	statCountWarnStyle := lipgloss.NewStyle().
 		Foreground(lipgloss.Color(theme.colorYellow)).Width(4).Align(lipgloss.Right)
 	if s == nil {
-		return genericStyle.Render(" ") + statCountStyle.Render(" ") + statCountStyle.Render(" ")
+		return remoteStyle.Render("☁") + statCountStyle.Render(" ") + statCountStyle.Render(" ")
 	} else {
 		str := ""
 		if s.Outdated {


### PR DESCRIPTION
This PR will add track stat after branch name for each active branch:

```
🌳 3 active branches
feat/branch-stats    1↑   ↓ Add ☁ for remote-only branch                               now RangerCD
test              ☁         Match branches without upstream by name                     4h RangerCD
main                  ↑   ↓ Bump ssh_config to v1.1.0                                   1w muesli
```

Each track stat has 2 parts:
- Stat indicator
- Ahead/behind metrics

## Stat indicator

| Indicator | Color | Meaning |
|-|-|-|
|`☁`| Cyan | Remote-only branch |
|`↻`| Red | Outdated reference, need `git fetch` |
| | - | Reference is up-to-date |

## Ahead/behind metrics

In format of `xxx↑xxx↓`, corresponding to `git rev-list --left-right --count <local branch>...<remote branch>`.
Some special cases:
- Any metric equals to `0`, number will be hiden
- Any metric greater than `99` will be shown as `99+`
- If both ahead/behind are `0`, arrows are shown in green
- If stat indicator is `☁`, nothing shows here
- If stat indicator is `↻`, metrics are not accurate unless `git fetch` updates remote branch reference

## TODO:
- [x] Show ahead/behind
- [x] Get stats after filtering branches
- [x] Mark `0↑0↓` with a different symbol
- [x] Mark remote branches out of sync with remote repo
- [x] Faster process speed(similar to `git rev-list`)
- [x] Match branches without upstream by name
- [x] Mark remote-only branch